### PR TITLE
Bug Fix: If invalid transaction is submitted blockfrost responded wit…

### DIFF
--- a/CardanoSharp.Blockfrost.Sdk/CardanoSharp.Blockfrost.Sdk.csproj
+++ b/CardanoSharp.Blockfrost.Sdk/CardanoSharp.Blockfrost.Sdk.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>0.0.13</Version>
+        <Version>0.0.14</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/CardanoSharp.Blockfrost.Sdk/ITransactionsClient.cs
+++ b/CardanoSharp.Blockfrost.Sdk/ITransactionsClient.cs
@@ -8,8 +8,8 @@ public interface ITransactionsClient
 	[Get("/txs/{hash}")]
 	Task<ApiResponse<Transaction>> GetTransactionAsync(string hash);
 
-	[Headers("Content-Type: application/cbor; charset=UTF-8")]
-	[Post("/tx/submit")]
+    [Headers("Content-Type: application/cbor")]
+    [Post("/tx/submit")]
 	Task<ApiResponse<string>> PostSubmitTransactionAsync([Body] Stream content);
 
     [Get("/txs/{hash}/utxos")]


### PR DESCRIPTION
The invalid header has been removed, If the invalid header is included when submitting an invalid transaction to the Blockfrost API it will respond with an HTTP 500 error instead of a 400 response containing the description of the problem.